### PR TITLE
feat: add per-host and per-route rate limiter mapping and git hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ example/example
 testdata/
 .github/copilot-instructions.md
 AGENTS.md
+QWEN.md

--- a/GIT_HOOKS.md
+++ b/GIT_HOOKS.md
@@ -1,0 +1,59 @@
+# Git Hooks Configuration
+
+This project uses Git hooks to enforce code quality and commit message standards.
+
+## Setting Up Git Hooks
+
+Git hooks are stored in the `githooks/` directory and need to be installed manually:
+
+```bash
+./install-hooks.sh
+```
+
+This script copies the hooks from `githooks/` to your local `.git/hooks/` directory and makes them executable.
+
+## Pre-commit Hook
+
+The pre-commit hook runs `act` to execute GitHub Actions locally before allowing a commit. This ensures that:
+- All tests pass
+- Code quality checks pass
+- Linting passes
+- The code is in a deployable state
+
+## Commit-msg Hook
+
+The commit-msg hook validates that commit messages follow these rules:
+1. **Prefix required**: Must follow conventional commits format `<type>(optional scope): description`
+   - Examples: `feat: add new feature`, `fix: resolve issue`, `docs: update readme`
+   - Valid types: `build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|wip`
+
+2. **Single line**: Commit messages should be concise and fit on a single line (excluding comments)
+
+3. **No AI keywords**: Commit messages must not contain AI-related terms like:
+   - `codex`, `copilot`, `claude`, `qwen`, `ai`, `artificial intelligence`, `machine learning`, `ml`, `chatgpt`, `gpt`, `openai`, `anthropic`
+
+## Valid Commit Message Examples
+
+```
+feat: add user authentication
+fix: resolve memory leak in cache implementation  
+docs: update API documentation
+refactor: improve error handling in client
+test: add unit tests for rate limiter
+chore: update dependencies
+```
+
+## Invalid Commit Message Examples
+
+```
+Add new feature  # (missing prefix)
+fix: resolve issue
+with more details  # (multi-line)
+feat: add new feature with AI assistance  # (contains AI keyword)
+```
+
+## Manual Testing
+
+If you want to test the hooks manually:
+- For pre-commit: Run `act` in the project root
+- For commit-msg: Create a test commit message file and run the validation script

--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Commit message validation hook
+# Validates that:
+# 1. Message has a prefix (type)
+# 2. Message is one line
+# 3. Message doesn't contain AI keywords
+
+COMMIT_MSG_FILE=$1
+COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
+
+# Check if message is empty
+if [ -z "$COMMIT_MSG" ]; then
+    echo "❌ Empty commit message. Please provide a descriptive message."
+    exit 1
+fi
+
+# Check if the message is more than one line (excluding comments)
+FIRST_LINE=$(echo "$COMMIT_MSG" | head -n 1)
+if [ -n "$(echo "$COMMIT_MSG" | tail -n +2 | grep -v '^#' | grep -v '^$')" ]; then
+    echo "❌ Commit message should be a single line (excluding comments)."
+    echo "Current message:"
+    echo "$COMMIT_MSG"
+    exit 1
+fi
+
+# Check for conventional commit prefix (type: message)
+PREFIX_PATTERN="^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|wip)(\(.+\))?: .+"
+
+if ! echo "$FIRST_LINE" | grep -qE "$PREFIX_PATTERN"; then
+    echo "❌ Commit message must follow conventional commits format: <type>(optional scope): <description>"
+    echo "Examples: feat: add new feature, fix: resolve issue, docs: update readme"
+    echo "Current message: $FIRST_LINE"
+    exit 1
+fi
+
+# Check for AI keywords (case-insensitive)
+AI_KEYWORDS="codex|copilot|claude|qwen|ai|artificial intelligence|machine learning|ml|chatgpt|gpt|openai|anthropic"
+
+if echo "$FIRST_LINE" | grep -qiE "$AI_KEYWORDS"; then
+    echo "❌ Commit message contains AI-related keywords which are not allowed: $AI_KEYWORDS"
+    echo "Current message: $FIRST_LINE"
+    exit 1
+fi
+
+echo "✅ Commit message is valid: $FIRST_LINE"
+exit 0

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Pre-commit hook to run act (GitHub Actions locally)
+echo "Running GitHub Actions locally with act..."
+
+# Run act to ensure tests and checks pass
+act
+
+if [ $? -ne 0 ]; then
+    echo "❌ GitHub Actions failed. Commit aborted."
+    exit 1
+fi
+
+echo "✅ GitHub Actions passed. Proceeding with commit..."
+exit 0

--- a/install-hooks.sh
+++ b/install-hooks.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Script to install git hooks
+# Run this script to copy hooks from the githooks directory to .git/hooks
+
+HOOKS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/githooks"
+
+if [ ! -d "$HOOKS_DIR" ]; then
+    echo "Error: githooks directory not found at $HOOKS_DIR"
+    exit 1
+fi
+
+GIT_HOOKS_DIR="$( git rev-parse --git-dir )/hooks"
+
+if [ ! -d "$GIT_HOOKS_DIR" ]; then
+    echo "Error: .git/hooks directory not found"
+    exit 1
+fi
+
+# Copy all hook files from githooks directory to .git/hooks
+for hook in "$HOOKS_DIR"/*; do
+    hook_name=$(basename "$hook")
+    destination="$GIT_HOOKS_DIR/$hook_name"
+    
+    cp "$hook" "$destination"
+    chmod +x "$destination"
+    
+    echo "Installed $hook_name to $GIT_HOOKS_DIR"
+done
+
+echo "Git hooks installed successfully!"

--- a/rate_limiter_registry.go
+++ b/rate_limiter_registry.go
@@ -1,0 +1,87 @@
+package klayengo
+
+import (
+	"net/http"
+	"sync"
+)
+
+// NewRateLimiterRegistry creates a new rate limiter registry with the given key function and fallback limiter.
+func NewRateLimiterRegistry(keyFunc KeyFunc, fallback Limiter) *RateLimiterRegistry {
+	return &RateLimiterRegistry{
+		limiters: make(map[string]Limiter),
+		keyFunc:  keyFunc,
+		fallback: fallback,
+		mutex:    sync.RWMutex{},
+	}
+}
+
+// RegisterLimiter adds a limiter for the given key.
+func (r *RateLimiterRegistry) RegisterLimiter(key string, limiter Limiter) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.limiters[key] = limiter
+}
+
+// GetLimiter returns the limiter for the given request, using the key function to determine the key.
+// If no specific limiter is found, returns the fallback limiter.
+func (r *RateLimiterRegistry) GetLimiter(req *http.Request) (Limiter, string) {
+	if r.keyFunc == nil {
+		if r.fallback != nil {
+			return r.fallback, "default"
+		}
+		return nil, "default"
+	}
+
+	key := r.keyFunc(req)
+
+	r.mutex.RLock()
+	limiter, exists := r.limiters[key]
+	r.mutex.RUnlock()
+
+	if exists {
+		return limiter, key
+	}
+
+	if r.fallback != nil {
+		return r.fallback, "default"
+	}
+
+	return nil, key
+}
+
+// Allow checks if a request is allowed by the appropriate rate limiter.
+func (r *RateLimiterRegistry) Allow(req *http.Request) (bool, string) {
+	limiter, key := r.GetLimiter(req)
+	if limiter == nil {
+		return true, key // No rate limiting if no limiter found
+	}
+	return limiter.Allow(), key
+}
+
+// DefaultHostKeyFunc generates a key based on the request host.
+func DefaultHostKeyFunc(req *http.Request) string {
+	if req.URL.Host != "" {
+		return "host:" + req.URL.Host
+	}
+	if req.Host != "" {
+		return "host:" + req.Host
+	}
+	return "host:unknown"
+}
+
+// DefaultRouteKeyFunc generates a key based on the request method and path.
+func DefaultRouteKeyFunc(req *http.Request) string {
+	return "route:" + req.Method + ":" + req.URL.Path
+}
+
+// DefaultHostRouteKeyFunc generates a key combining host and route.
+func DefaultHostRouteKeyFunc(req *http.Request) string {
+	host := req.URL.Host
+	if host == "" {
+		host = req.Host
+	}
+	if host == "" {
+		host = "unknown"
+	}
+	return "host_route:" + host + ":" + req.Method + ":" + req.URL.Path
+}

--- a/rate_limiter_registry_test.go
+++ b/rate_limiter_registry_test.go
@@ -1,0 +1,179 @@
+package klayengo
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	testHost         = "api.example.com"
+	testHostKey      = "host:api.example.com"
+	defaultKey       = "default"
+	fallbackMsg      = "Expected fallback limiter, got %v"
+	keyMsg           = "Expected key '%s', got %s"
+	firstReqMsg      = "First request should be allowed"
+	secondReqMsg     = "Second request should be denied"
+	concurrentMsg    = "Concurrent access failed: expected %s, got %s"
+	hostKeyMsg       = "Expected host key %s, got %s"
+	routeKeyMsg      = "Expected route key %s, got %s"
+	hostRouteKeyMsg  = "Expected host-route key %s, got %s"
+	nilLimiterMsg    = "Expected nil limiter, got %v"
+	allowMsg         = "Expected request to be allowed when no limiter is configured"
+)
+
+func TestRateLimiterRegistryGetLimiter(t *testing.T) {
+	limiter1 := NewRateLimiter(10, time.Second)
+	limiter2 := NewRateLimiter(20, time.Second)
+
+	registry := NewRateLimiterRegistry(DefaultHostKeyFunc, limiter1)
+
+	// Test fallback limiter
+	req1 := &http.Request{Host: "unknown.com", URL: &url.URL{}}
+	limiter, key := registry.GetLimiter(req1)
+	if limiter != limiter1 {
+		t.Errorf(fallbackMsg, limiter)
+	}
+	if key != defaultKey {
+		t.Errorf(keyMsg, defaultKey, key)
+	}
+
+	// Register specific limiter
+	registry.RegisterLimiter(testHostKey, limiter2)
+
+	// Test specific limiter
+	req2 := &http.Request{URL: &url.URL{Host: testHost}}
+	limiter, key = registry.GetLimiter(req2)
+	if limiter != limiter2 {
+		t.Errorf("Expected specific limiter, got %v", limiter)
+	}
+	if key != testHostKey {
+		t.Errorf(keyMsg, testHostKey, key)
+	}
+
+	// Test fallback for unregistered host
+	req3 := &http.Request{URL: &url.URL{Host: "other.com"}}
+	limiter, key = registry.GetLimiter(req3)
+	if limiter != limiter1 {
+		t.Errorf(fallbackMsg, limiter)
+	}
+	if key != defaultKey {
+		t.Errorf(keyMsg, defaultKey, key)
+	}
+}
+
+func TestRateLimiterRegistryAllow(t *testing.T) {
+	limiter := NewRateLimiter(1, time.Hour) // Very slow refill, so we can test limiting
+	registry := NewRateLimiterRegistry(DefaultHostKeyFunc, limiter)
+
+	req := &http.Request{URL: &url.URL{Host: testHost}}
+
+	// First request should be allowed
+	allowed, key := registry.Allow(req)
+	if !allowed {
+		t.Error(firstReqMsg)
+	}
+	if key != defaultKey {
+		t.Errorf(keyMsg, defaultKey, key)
+	}
+
+	// Second request should be denied (only 1 token)
+	allowed, key = registry.Allow(req)
+	if allowed {
+		t.Error(secondReqMsg)
+	}
+	if key != defaultKey {
+		t.Errorf(keyMsg, defaultKey, key)
+	}
+}
+
+func TestRateLimiterRegistryConcurrency(t *testing.T) {
+	registry := NewRateLimiterRegistry(DefaultHostKeyFunc, nil)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+
+			limiter := NewRateLimiter(100, time.Second)
+			key := fmt.Sprintf("host:test%d.com", id)
+			registry.RegisterLimiter(key, limiter)
+
+			// Test concurrent access
+			for j := 0; j < 10; j++ {
+				req := &http.Request{URL: &url.URL{Host: fmt.Sprintf("test%d.com", id)}}
+				_, retrievedKey := registry.GetLimiter(req)
+				if retrievedKey != key {
+					t.Errorf(concurrentMsg, key, retrievedKey)
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func TestDefaultKeyFuncs(t *testing.T) {
+	req := &http.Request{
+		Method: "GET",
+		URL:    &url.URL{Host: testHost, Path: "/users"},
+	}
+
+	// Test host key func
+	hostKey := DefaultHostKeyFunc(req)
+	if hostKey != testHostKey {
+		t.Errorf(hostKeyMsg, testHostKey, hostKey)
+	}
+
+	// Test route key func
+	routeKey := DefaultRouteKeyFunc(req)
+	expectedRouteKey := "route:GET:/users"
+	if routeKey != expectedRouteKey {
+		t.Errorf(routeKeyMsg, expectedRouteKey, routeKey)
+	}
+
+	// Test host-route key func
+	hostRouteKey := DefaultHostRouteKeyFunc(req)
+	expectedHostRouteKey := "host_route:api.example.com:GET:/users"
+	if hostRouteKey != expectedHostRouteKey {
+		t.Errorf(hostRouteKeyMsg, expectedHostRouteKey, hostRouteKey)
+	}
+}
+
+func TestRateLimiterRegistryNoKeyFunc(t *testing.T) {
+	limiter := NewRateLimiter(10, time.Second)
+	registry := NewRateLimiterRegistry(nil, limiter)
+
+	req := &http.Request{URL: &url.URL{Host: testHost}}
+
+	limiterResult, key := registry.GetLimiter(req)
+	if limiterResult != limiter {
+		t.Errorf(fallbackMsg, limiterResult)
+	}
+	if key != defaultKey {
+		t.Errorf(keyMsg, defaultKey, key)
+	}
+}
+
+func TestRateLimiterRegistryNoLimiter(t *testing.T) {
+	registry := NewRateLimiterRegistry(DefaultHostKeyFunc, nil)
+
+	req := &http.Request{URL: &url.URL{Host: testHost}}
+
+	limiter, key := registry.GetLimiter(req)
+	if limiter != nil {
+		t.Errorf(nilLimiterMsg, limiter)
+	}
+	if key != testHostKey {
+		t.Errorf(keyMsg, testHostKey, key)
+	}
+
+	allowed, _ := registry.Allow(req)
+	if !allowed {
+		t.Error(allowMsg)
+	}
+}


### PR DESCRIPTION
This PR adds:\n\n1. Per-host and per-route rate limiter mapping functionality\n2. Git hooks for CI validation and commit message validation\n\nIncludes:\n- New rate limiter registry for managing per-host/route limits\n- Git hooks for pre-commit validation (runs act)\n- Commit message validation to ensure conventional format\n- Documentation for the new features\n\nThis represents the changes for version 1.3.0.